### PR TITLE
Add allowed values to `enum` errors, details to `items` errors

### DIFF
--- a/items.go
+++ b/items.go
@@ -43,6 +43,7 @@ func evaluateItems(schema *Schema, array []interface{}, evaluatedProps map[strin
 				if result.IsValid() {
 					evaluatedItems[i] = true // Mark the item as evaluated if it passes schema validation.
 				} else {
+					results = append(results, result)
 					invalid_indexs = append(invalid_indexs, strconv.Itoa(i))
 				}
 			}

--- a/locales/en.json
+++ b/locales/en.json
@@ -17,7 +17,7 @@
   "dependent_property_required":     "Some required property dependencies are missing: {missing_properties}",
   "dependent_schema_mismatch":       "Property {property} does not match the dependent schema",
   "dependent_schemas_mismatch":      "Properties {properties} do not match the dependent schema",
-  "value_not_in_enum":               "Value should match one of the values specified by the enum",
+  "value_not_in_enum":               "Value {received} should be one of the allowed values: {expected}",
   "exclusive_maximum_mismatch":      "{value} should be less than {exclusive_maximum}",
   "exclusive_minimum_mismatch":      "{value} should be greater than {exclusive_minimum}",
   "unsupported_format":              "Format {format} is not supported",


### PR DESCRIPTION
- [feat: improve enum validation errors](https://github.com/kaptinlin/jsonschema/commit/49ab71a730036564b1c3c4e1b7c7656ce40125f3) 

    Instead of returning "Value should match one of the values specified by the enum", let's provide a more helpful error message similar to the one used by `type`: "Value {received} should be one of the allowed values: {expected}", where `expected` is a comma-separated list of Go string representations (i.e. `%v`) of the values passed to `enum`.

    **Note** that I have updated the `en` locale error message, but I didn't make the same change to the other supported locales as I'm not fluent enough in any of them.

- [fix: return details when items validation fails](https://github.com/kaptinlin/jsonschema/commit/5b404b7d78dcd99dd871ced52981997a7ebe6e8d) 

    Due to a missing `append()`, the `items` validator did not return any details about the errors encountered except for the failing indexes, which makes it hard for users to understand why there has been an error in the first place.

Closes #22 