### PR TITLE
feat: sort properties prior rendering to errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kaptinlin/jsonschema
 
-go 1.24.0
+go 1.23.0
 
 require (
 	github.com/bytedance/sonic v1.12.9

--- a/properties.go
+++ b/properties.go
@@ -2,6 +2,7 @@ package jsonschema
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -65,6 +66,7 @@ func evaluateProperties(schema *Schema, object map[string]interface{}, evaluated
 			"property": fmt.Sprintf("'%s'", invalid_properties[0]),
 		})
 	} else if len(invalid_properties) > 1 {
+		slices.Sort(invalid_properties)
 		quotedProperties := make([]string, len(invalid_properties))
 		for i, prop := range invalid_properties {
 			quotedProperties[i] = fmt.Sprintf("'%s'", prop)


### PR DESCRIPTION
This makes the results stable so the output JSON can be compared, fixes: https://github.com/kaptinlin/jsonschema/issues/28

Typically, there are just couple of errors therefore sorting should not be a performance concern.

Tests in `main` do appear to fail, not sure what is wrong there. Cheers!

