### PR TITLE
Cache a string pattern

### DIFF
--- a/pattern.go
+++ b/pattern.go
@@ -14,8 +14,8 @@ import "regexp"
 // Reference: https://json-schema.org/draft/2020-12/json-schema-validation#name-pattern
 func evaluatePattern(schema *Schema, instance string) *EvaluationError {
 	if schema.Pattern != nil {
-		// Compile the regular expression from the pattern.
-		regExp, err := regexp.Compile(*schema.Pattern)
+		// Gets a compiled regular expression, or compiles and caches it if not already present.
+		regExp, err := getCompiledPattern(schema)
 		if err != nil {
 			// Handle regular expression compilation errors.
 			return NewEvaluationError("pattern", "invalid_pattern", "Invalid regular expression pattern {pattern}", map[string]interface{}{
@@ -33,4 +33,16 @@ func evaluatePattern(schema *Schema, instance string) *EvaluationError {
 		}
 	}
 	return nil
+}
+
+func getCompiledPattern(schema *Schema) (*regexp.Regexp, error) {
+	if schema.compiledStringPattern == nil {
+		regExp, err := regexp.Compile(*schema.Pattern)
+		if err != nil {
+			return nil, err
+		}
+		schema.compiledStringPattern = regExp
+	}
+
+	return schema.compiledStringPattern, nil
 }

--- a/schema.go
+++ b/schema.go
@@ -9,14 +9,15 @@ import (
 // Schema represents a JSON Schema as per the 2020-12 draft, containing all
 // necessary metadata and validation properties defined by the specification.
 type Schema struct {
-	compiledPatterns map[string]*regexp.Regexp // Cached compiled regular expressions for pattern properties.
-	compiler         *Compiler                 // Reference to the associated Compiler instance.
-	parent           *Schema                   // Parent schema for hierarchical resolution.
-	uri              string                    // Internal schema identifier resolved during compilation.
-	baseURI          string                    // Base URI for resolving relative references within the schema.
-	anchors          map[string]*Schema        // Anchors for quick lookup of internal schema references.
-	dynamicAnchors   map[string]*Schema        // Dynamic anchors for more flexible schema references.
-	schemas          map[string]*Schema        // Cache of compiled schemas.
+	compiledPatterns      map[string]*regexp.Regexp // Cached compiled regular expressions for pattern properties.
+	compiler              *Compiler                 // Reference to the associated Compiler instance.
+	parent                *Schema                   // Parent schema for hierarchical resolution.
+	uri                   string                    // Internal schema identifier resolved during compilation.
+	baseURI               string                    // Base URI for resolving relative references within the schema.
+	anchors               map[string]*Schema        // Anchors for quick lookup of internal schema references.
+	dynamicAnchors        map[string]*Schema        // Dynamic anchors for more flexible schema references.
+	schemas               map[string]*Schema        // Cache of compiled schemas.
+	compiledStringPattern *regexp.Regexp            // Cached compiled regular expressions for string patterns.
 
 	ID     string  `json:"$id,omitempty"`     // Public identifier for the schema.
 	Schema string  `json:"$schema,omitempty"` // URI indicating the specification the schema conforms to.


### PR DESCRIPTION
## Summary
This PR enhances performance by caching compiled regular expressions used for string pattern validation.​

## Details
Previously, the code compiled the regular expression for string pattern validation each time it was needed, which could lead to performance issues due to redundant compilation. This change introduces a caching mechanism that stores compiled regular expressions, ensuring that each unique pattern is compiled only once and reused thereafter.​

## Motivation
In scenarios where the same pattern is validated multiple times, recompiling the regular expression each time is inefficient. By caching the compiled patterns, we reduce unnecessary computations, leading to improved performance, especially in validation-heavy operations.​