### PR TITLE
feat: export method to get unresolved refs on Schema

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -149,7 +149,7 @@ func (c *Compiler) Compile(jsonSchema []byte, uris ...string) (*Schema, error) {
 // trackUnresolvedReferences tracks which schemas have unresolved references to which URIs
 // This method should be called with mutex locked
 func (c *Compiler) trackUnresolvedReferences(schema *Schema) {
-	unresolvedURIs := schema.getUnresolvedReferenceURIs()
+	unresolvedURIs := schema.GetUnresolvedReferenceURIs()
 	for _, uri := range unresolvedURIs {
 		if c.unresolvedRefs[uri] == nil {
 			c.unresolvedRefs[uri] = make([]*Schema, 0)

--- a/ref.go
+++ b/ref.go
@@ -261,8 +261,8 @@ func resolveUnresolvedInList(schemas []*Schema) {
 	}
 }
 
-// getUnresolvedReferenceURIs returns a list of URIs that this schema references but are not yet resolved
-func (s *Schema) getUnresolvedReferenceURIs() []string {
+// GetUnresolvedReferenceURIs returns a list of URIs that this schema references but are not yet resolved
+func (s *Schema) GetUnresolvedReferenceURIs() []string {
 	var unresolvedURIs []string
 
 	// Check direct references
@@ -277,14 +277,14 @@ func (s *Schema) getUnresolvedReferenceURIs() []string {
 	// Recursively check nested schemas
 	if s.Defs != nil {
 		for _, defSchema := range s.Defs {
-			unresolvedURIs = append(unresolvedURIs, defSchema.getUnresolvedReferenceURIs()...)
+			unresolvedURIs = append(unresolvedURIs, defSchema.GetUnresolvedReferenceURIs()...)
 		}
 	}
 
 	if s.Properties != nil {
 		for _, propSchema := range *s.Properties {
 			if propSchema != nil {
-				unresolvedURIs = append(unresolvedURIs, propSchema.getUnresolvedReferenceURIs()...)
+				unresolvedURIs = append(unresolvedURIs, propSchema.GetUnresolvedReferenceURIs()...)
 			}
 		}
 	}
@@ -295,30 +295,30 @@ func (s *Schema) getUnresolvedReferenceURIs() []string {
 	unresolvedURIs = append(unresolvedURIs, getUnresolvedFromList(s.OneOf)...)
 
 	if s.Not != nil {
-		unresolvedURIs = append(unresolvedURIs, s.Not.getUnresolvedReferenceURIs()...)
+		unresolvedURIs = append(unresolvedURIs, s.Not.GetUnresolvedReferenceURIs()...)
 	}
 
 	if s.Items != nil {
-		unresolvedURIs = append(unresolvedURIs, s.Items.getUnresolvedReferenceURIs()...)
+		unresolvedURIs = append(unresolvedURIs, s.Items.GetUnresolvedReferenceURIs()...)
 	}
 
 	if s.PrefixItems != nil {
 		for _, schema := range s.PrefixItems {
-			unresolvedURIs = append(unresolvedURIs, schema.getUnresolvedReferenceURIs()...)
+			unresolvedURIs = append(unresolvedURIs, schema.GetUnresolvedReferenceURIs()...)
 		}
 	}
 
 	if s.AdditionalProperties != nil {
-		unresolvedURIs = append(unresolvedURIs, s.AdditionalProperties.getUnresolvedReferenceURIs()...)
+		unresolvedURIs = append(unresolvedURIs, s.AdditionalProperties.GetUnresolvedReferenceURIs()...)
 	}
 
 	if s.Contains != nil {
-		unresolvedURIs = append(unresolvedURIs, s.Contains.getUnresolvedReferenceURIs()...)
+		unresolvedURIs = append(unresolvedURIs, s.Contains.GetUnresolvedReferenceURIs()...)
 	}
 
 	if s.PatternProperties != nil {
 		for _, schema := range *s.PatternProperties {
-			unresolvedURIs = append(unresolvedURIs, schema.getUnresolvedReferenceURIs()...)
+			unresolvedURIs = append(unresolvedURIs, schema.GetUnresolvedReferenceURIs()...)
 		}
 	}
 
@@ -330,7 +330,7 @@ func getUnresolvedFromList(schemas []*Schema) []string {
 	var unresolvedURIs []string
 	for _, schema := range schemas {
 		if schema != nil {
-			unresolvedURIs = append(unresolvedURIs, schema.getUnresolvedReferenceURIs()...)
+			unresolvedURIs = append(unresolvedURIs, schema.GetUnresolvedReferenceURIs()...)
 		}
 	}
 	return unresolvedURIs


### PR DESCRIPTION
Export `(*Schema).GetUnresolvedReferenceURIs` to allow users to determine if all references for a schema have been successfully resolved.

The main goal of this change is to allow users of the package to detect when a schema isn't fully resolved which can cause unexpected issues with validation. I didn't see any existing way to accomplish this but let me know if I missed something!