### PR TITLE
feat: migrate to standard library JSON v2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ task bench                           # Package benchmarks
 
 | Dependency | Purpose |
 |------------|---------|
-| `github.com/go-json-experiment/json` | Primary JSON encoder/decoder backend and streaming support. |
+| `encoding/json/v2` | Standard library JSON encoder/decoder backend and streaming support. |
 | `github.com/kaptinlin/jsonpointer` | JSON Pointer parsing and reference resolution. |
 | `github.com/kaptinlin/go-i18n` | Localized validation messages and result rendering. |
 | `github.com/goccy/go-yaml` | YAML decoding support for content-related workflows. |

--- a/compiler.go
+++ b/compiler.go
@@ -13,8 +13,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-json-experiment/json"
-	"github.com/go-json-experiment/json/jsontext"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
+
 	"github.com/goccy/go-yaml"
 )
 
@@ -126,7 +127,7 @@ func NewCompiler() *Compiler {
 		customFormats:  make(map[string]*FormatDef),
 		defaultDialect: Draft202012,
 
-		// Default to go-json-experiment JSON implementation
+		// Default to the standard library JSON v2 implementation.
 		jsonEncoder: func(v any) ([]byte, error) { return marshalJSON(v) },
 		jsonDecoder: unmarshalJSON,
 	}

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -12,7 +12,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-json-experiment/json"
+	"encoding/json/v2"
+
 	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/const.go
+++ b/const.go
@@ -19,7 +19,13 @@ func evaluateConst(schema *Schema, instance any) *EvaluationError {
 	}
 
 	if schema.Const.Value == nil {
-		return NewEvaluationError("const", "const_mismatch_null", "Value should be null")
+		return NewEvaluationError("const", "const_mismatch_null", "Value should be null", map[string]any{
+			"expected": nil,
+			"received": instance,
+		})
 	}
-	return NewEvaluationError("const", "const_mismatch", "Value does not match the constant value")
+	return NewEvaluationError("const", "const_mismatch", "Value does not match the constant value", map[string]any{
+		"expected": schema.Const.Value,
+		"received": instance,
+	})
 }

--- a/dependent_required.go
+++ b/dependent_required.go
@@ -1,7 +1,7 @@
 package jsonschema
 
 import (
-	"github.com/go-json-experiment/json"
+	"encoding/json/v2"
 )
 
 // evaluateDependentRequired checks that if a specified property is present, all its dependent properties are also present.

--- a/dialect.go
+++ b/dialect.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-json-experiment/json"
-	"github.com/go-json-experiment/json/jsontext"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
 )
 
 const recursiveDynamicAnchor = "__jsonschema_recursive_anchor__"

--- a/dialect_extra_test.go
+++ b/dialect_extra_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/go-json-experiment/json"
+	"encoding/json/v2"
 )
 
 // compileWithExtra compiles doc under dialect d while preserving extension

--- a/embedding_test.go
+++ b/embedding_test.go
@@ -3,8 +3,9 @@ package jsonschema
 import (
 	"testing"
 
-	"github.com/go-json-experiment/json"
-	"github.com/go-json-experiment/json/jsontext"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/enum.go
+++ b/enum.go
@@ -38,6 +38,7 @@ func evaluateEnum(schema *Schema, instance any) *EvaluationError {
 
 	return NewEvaluationError("enum", "value_not_in_enum", "Value {received} should be one of the allowed values: {expected}", map[string]any{
 		"expected": strings.Join(allowed, ", "),
+		"allowed":  schema.Enum,
 		"received": instance,
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,32 +1,25 @@
 module github.com/kaptinlin/jsonschema
 
-go 1.26.5
-
-require (
-	github.com/kaptinlin/go-i18n v0.6.3
-	github.com/stretchr/testify v1.11.1
-)
+go 1.27
 
 require (
 	github.com/agentable/go-intl v0.2.14 // indirect
 	github.com/cockroachdb/apd/v3 v3.2.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68 // indirect
 	github.com/kaptinlin/messageformat-go/mf1 v0.8.3 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
+	golang.org/x/text v0.40.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-require github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68
-
 require (
-	github.com/google/uuid v1.6.0
-	github.com/kaptinlin/jsonpointer v0.4.28
-)
-
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/goccy/go-yaml v1.19.2
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/text v0.40.0 // indirect
+	github.com/google/uuid v1.6.0
+	github.com/kaptinlin/go-i18n v0.6.3
+	github.com/kaptinlin/jsonpointer v0.4.28
+	github.com/stretchr/testify v1.11.1
 )

--- a/metaschema.go
+++ b/metaschema.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/go-json-experiment/json/jsontext"
+	"encoding/json/jsontext"
 )
 
 // ValidateSchema validates a JSON Schema document against its declared

--- a/omitzero_test.go
+++ b/omitzero_test.go
@@ -4,7 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-json-experiment/json"
+	"encoding/json/v2"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/pattern.go
+++ b/pattern.go
@@ -7,17 +7,18 @@ func evaluatePattern(schema *Schema, instance string) *EvaluationError {
 		return nil
 	}
 
-	if schema.compiledStringPattern == nil {
-		regExp, err := regexp.Compile(*schema.Pattern)
+	regExp := schema.compiledStringPattern
+	if regExp == nil {
+		var err error
+		regExp, err = regexp.Compile(*schema.Pattern)
 		if err != nil {
 			return NewEvaluationError("pattern", "invalid_pattern", "Invalid regular expression pattern {pattern}", map[string]any{
 				"pattern": *schema.Pattern,
 			})
 		}
-		schema.compiledStringPattern = regExp
 	}
 
-	if !schema.compiledStringPattern.MatchString(instance) {
+	if !regExp.MatchString(instance) {
 		return NewEvaluationError("pattern", "pattern_mismatch", "Value does not match the required pattern {pattern}", map[string]any{
 			"pattern": *schema.Pattern,
 			"value":   instance,

--- a/pattern_properties.go
+++ b/pattern_properties.go
@@ -52,7 +52,6 @@ func evaluatePatternProperties(
 				}
 				continue
 			}
-			schema.compiledPatterns[patternKey] = regex
 		}
 
 		for propName, propValue := range object {

--- a/rat.go
+++ b/rat.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/go-json-experiment/json/jsontext"
+	"encoding/json/jsontext"
 )
 
 // Rat wraps a big.Rat to enable custom JSON marshaling and unmarshaling.

--- a/result_test.go
+++ b/result_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/go-json-experiment/json"
-	"github.com/go-json-experiment/json/jsontext"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
 )
 
 // Define the JSON schema

--- a/roundtrip_test.go
+++ b/roundtrip_test.go
@@ -3,7 +3,8 @@ package jsonschema
 import (
 	"testing"
 
-	"github.com/go-json-experiment/json"
+	"encoding/json/v2"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/schema.go
+++ b/schema.go
@@ -9,8 +9,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-json-experiment/json"
-	"github.com/go-json-experiment/json/jsontext"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
+
 	"github.com/kaptinlin/jsonpointer"
 )
 
@@ -580,7 +581,7 @@ func (s *Schema) UnmarshalJSON(data []byte) error {
 		// Const is captured as a raw token so "const": null is preserved
 		// (a *ConstValue field would be niled by the decoder, losing IsSet).
 		Const jsontext.Value            `json:"const,omitempty"`
-		Rest  map[string]jsontext.Value `json:",embed"` //nolint:staticcheck // go-json-experiment/json v2 uses embed for fallback fields.
+		Rest  map[string]jsontext.Value `json:",embed"` // encoding/json/v2 uses embed for fallback fields.
 		*Alias
 	}{
 		Alias: (*Alias)(s),

--- a/schema.go
+++ b/schema.go
@@ -192,6 +192,7 @@ func (s *Schema) initializeSchemaCore(compiler *Compiler, parent *Schema, resolv
 
 	// Initialize nested schemas
 	initializeNestedSchemasCore(s, compiler, resolveRefs)
+	s.compileRegexCaches()
 	if resolveRefs {
 		s.resolveReferences()
 	}
@@ -200,6 +201,17 @@ func (s *Schema) initializeSchemaCore(compiler *Compiler, parent *Schema, resolv
 	if effectiveCompiler != nil && !effectiveCompiler.PreserveExtra {
 		s.Extra = nil
 	}
+}
+
+// compileRegexCaches prepares immutable regular-expression state before a
+// compiled schema is published for validation. Invalid expressions are left
+// unset and reported by validateRegexSyntax.
+func (s *Schema) compileRegexCaches() {
+	if s.Pattern != nil {
+		s.compiledStringPattern, _ = regexp.Compile(*s.Pattern)
+	}
+
+	s.compilePatterns()
 }
 
 // resolveBaseURI resolves the base URI for the schema

--- a/schema_decode.go
+++ b/schema_decode.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/go-json-experiment/json"
-	"github.com/go-json-experiment/json/jsontext"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
 )
 
 func decodeExclusiveBound(keyword string, raw jsontext.Value, target **Rat, legacy *jsontext.Value) error {

--- a/schema_test.go
+++ b/schema_test.go
@@ -5,8 +5,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/go-json-experiment/json"
-	"github.com/go-json-experiment/json/jsontext"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/struct_tags_test.go
+++ b/struct_tags_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-json-experiment/json"
-	"github.com/go-json-experiment/json/jsontext"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/struct_validation_test.go
+++ b/struct_validation_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-json-experiment/json"
-	"github.com/go-json-experiment/json/jsontext"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
 )
 
 // =============================================================================

--- a/tests/const_test.go
+++ b/tests/const_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/go-json-experiment/json"
-	"github.com/go-json-experiment/json/jsontext"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
 
 	"github.com/kaptinlin/jsonschema"
 )

--- a/tests/exclusive_maximum_test.go
+++ b/tests/exclusive_maximum_test.go
@@ -3,7 +3,8 @@ package tests
 import (
 	"testing"
 
-	"github.com/go-json-experiment/json"
+	"encoding/json/v2"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/tests/exclusive_minimum_test.go
+++ b/tests/exclusive_minimum_test.go
@@ -3,7 +3,8 @@ package tests
 import (
 	"testing"
 
-	"github.com/go-json-experiment/json"
+	"encoding/json/v2"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/tests/extras_test.go
+++ b/tests/extras_test.go
@@ -4,7 +4,8 @@ import (
 	stdjson "encoding/json"
 	"testing"
 
-	"github.com/go-json-experiment/json"
+	"encoding/json/v2"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/tests/id_test.go
+++ b/tests/id_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/go-json-experiment/json"
+	"encoding/json/v2"
 
 	"github.com/kaptinlin/jsonschema"
 )

--- a/tests/max_length_test.go
+++ b/tests/max_length_test.go
@@ -3,7 +3,8 @@ package tests
 import (
 	"testing"
 
-	"github.com/go-json-experiment/json"
+	"encoding/json/v2"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/tests/maximum_test.go
+++ b/tests/maximum_test.go
@@ -3,7 +3,8 @@ package tests
 import (
 	"testing"
 
-	"github.com/go-json-experiment/json"
+	"encoding/json/v2"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/tests/min_length_test.go
+++ b/tests/min_length_test.go
@@ -3,7 +3,8 @@ package tests
 import (
 	"testing"
 
-	"github.com/go-json-experiment/json"
+	"encoding/json/v2"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/tests/minimum_test.go
+++ b/tests/minimum_test.go
@@ -3,7 +3,8 @@ package tests
 import (
 	"testing"
 
-	"github.com/go-json-experiment/json"
+	"encoding/json/v2"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/tests/multiple_of_test.go
+++ b/tests/multiple_of_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/go-json-experiment/json"
+	"encoding/json/v2"
 
 	"github.com/kaptinlin/jsonschema"
 )

--- a/tests/pattern_test.go
+++ b/tests/pattern_test.go
@@ -3,7 +3,8 @@ package tests
 import (
 	"testing"
 
-	"github.com/go-json-experiment/json"
+	"encoding/json/v2"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/tests/test_suite_test.go
+++ b/tests/test_suite_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-json-experiment/json"
+	"encoding/json/v2"
 
 	"github.com/kaptinlin/jsonschema"
 )

--- a/tests/types_test.go
+++ b/tests/types_test.go
@@ -3,7 +3,8 @@ package tests
 import (
 	"testing"
 
-	"github.com/go-json-experiment/json"
+	"encoding/json/v2"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/tests/version_test.go
+++ b/tests/version_test.go
@@ -3,7 +3,8 @@ package tests
 import (
 	"testing"
 
-	"github.com/go-json-experiment/json"
+	"encoding/json/v2"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/validate.go
+++ b/validate.go
@@ -96,10 +96,6 @@ func (s *Schema) evaluate(instance any, dynamicScope *DynamicScope) (*Evaluation
 		return result, evaluatedProps, evaluatedItems
 	}
 
-	if s.PatternProperties != nil {
-		s.compilePatterns()
-	}
-
 	s.processReferences(instance, dynamicScope, result, evaluatedProps, evaluatedItems)
 	if s.Ref != "" && s.Dialect().refIgnoresSiblings() {
 		return result, evaluatedProps, evaluatedItems

--- a/validate_test.go
+++ b/validate_test.go
@@ -4,6 +4,7 @@ import (
 	stdjson "encoding/json"
 	"math"
 	"reflect"
+	"sync"
 	"testing"
 
 	"encoding/json/jsontext"
@@ -520,8 +521,9 @@ func TestValidateRequiredPropertyWithDefault(t *testing.T) {
 	})
 }
 
-func TestEvaluatePatternCachesCompiledPattern(t *testing.T) {
+func TestEvaluatePatternUsesPrecompiledPattern(t *testing.T) {
 	schema := &Schema{Pattern: new("^[A-Za-z]+$")}
+	schema.compileRegexCaches()
 
 	err := evaluatePattern(schema, "Alice")
 	require.Nil(t, err)
@@ -541,6 +543,34 @@ func TestEvaluatePatternCachesCompiledPattern(t *testing.T) {
 		"pattern": "^[A-Za-z]+$",
 		"value":   "Bob123",
 	}, err.Params)
+}
+
+func TestValidateJSONConcurrentSafe(t *testing.T) {
+	compiler := NewCompiler()
+	schema, err := compiler.Compile([]byte(`{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string", "pattern": "^[A-Za-z]+$"}
+		},
+		"patternProperties": {
+			"^x-": {"type": "string"}
+		}
+	}`))
+	require.NoError(t, err)
+
+	const workers = 32
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				result := schema.ValidateJSON([]byte(`{"name":"Alice","x-label":"ok"}`))
+				assert.True(t, result.IsValid())
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 func TestEvaluatePatternInvalidPattern(t *testing.T) {

--- a/validate_test.go
+++ b/validate_test.go
@@ -6,7 +6,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-json-experiment/json/jsontext"
+	"encoding/json/jsontext"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
## Summary

- require Go 1.27 and replace direct `github.com/go-json-experiment/json` imports with `encoding/json/v2`
- replace experimental `jsontext` imports with `encoding/json/jsontext`
- retain exact-number marshalers, unmarshalers, streaming APIs, and JSON v2 semantics
- expose machine-readable `expected`, `received`, and `allowed` params for const/enum validation errors
- precompile `pattern` and `patternProperties` expressions so compiled schemas are immutable and safe for concurrent validation
- remove the obsolete staticcheck suppression for the standard `json:",embed"` tag while preserving its explanatory comment

The experimental module remains an indirect dependency through `github.com/kaptinlin/go-i18n`; migrating that separate module is outside this PR.

## Verification

- `go test ./...`
- `go test -race ./...`
- concurrent `ValidateJSON` regression coverage for `pattern` and `patternProperties`
- `go vet ./...`
- `golangci-lint run --timeout=30m --concurrency=1 --path-prefix=.` (0 issues)
- `go mod tidy`
- `git diff --check`
